### PR TITLE
Added reference link to TILT document to label.html

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -166,9 +166,11 @@ def label(task_id):
     translator = Translator()
     [label.update(name=translator.translate(label["name"])) for label in task.labels]
 
-    # define the API target url and the url to redirect to
+    # define the API target url, the url to redirect to and the TILT doc reference link
     target_url = request.url_root + 'api/task/' + str(task_id) + '/annotation/json'
+    tilt_ref_url = request.url_root + 'api/task/' + str(task_id) + '/tilt'
     redirect_url = request.base_url
+
 
     # define colors for labels
     colors = ['blue', 'red', '#1CBA3D', '#13812A', 'orange', 'magenta', 'pink', 'brown', '#B986D4', '#8FA1E2', 'dimgrey',
@@ -182,7 +184,7 @@ def label(task_id):
     return render_template('label.html', task=task, target_url=target_url, annotations=annotations,
                            redirect_url=redirect_url, colors=colors,
                            annotation_descriptions=annotation_descriptions,
-                           manual_bools=manual_bools, tooltips=tooltips, token=token)
+                           manual_bools=manual_bools, tooltips=tooltips, token=token, tilt_ref_url=tilt_ref_url)
 
 
 # API Setup

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -132,8 +132,16 @@ button.create-task:hover {
     background: rgba(51, 51, 51, 0.78);
 }
 
-div.return {
+div.navigation-links {
     margin-bottom: 1em;
+}
+
+a.navigation-link {
+    margin-right: 1em;
+}
+
+.navigation-link i {
+    margin-right: 0.5em;
 }
 
 table.explanation {

--- a/app/templates/label.html
+++ b/app/templates/label.html
@@ -6,8 +6,9 @@
 
     <h1>{% block title %} {{ _('Welcome to TILTer') }} {% endblock %}</h1>
     <h2>{{ _('Task') }} "{{ task.name }}" <!--button id="publish" class="btn btn-outline-success btn-sm"><i class="fas fa-upload"></i> Publish to tilt-hub</button> <button id="unpublish" class="btn btn-outline-danger btn-sm"><i class="fas fa-trash"></i> Delete from tilt-hub</button--></h2>
-    <div class="return">
-        <a href="{{ url_for('tasks') }}"><i class="fas fa-long-arrow-alt-left"></i> {{ _('task overview') }}</a>
+    <div class="navigation-links">
+        <a class="navigation-link" href="{{ url_for('tasks') }}"><i class="fa fa-long-arrow-alt-left"></i> {{ _('task overview') }}</a>
+        <a class="navigation-link" href="{{ tilt_ref_url }}"><i class="fa fa-link"></i>TILT representation</a>
     </div>
     {% if annotation_descriptions %}
         <div>


### PR DESCRIPTION
This PR implements a reference link in `label.html`, which points towards the TILT document of the shown policy.
Closes #106